### PR TITLE
Adds context menu item to trigger synchronization manually

### DIFF
--- a/src/CalendarContextMenu.cs
+++ b/src/CalendarContextMenu.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms;
 using Microsoft.Office.Interop.Outlook;
 using TogglOutlookPlugIn.Models;
 using TogglOutlookPlugIn.Services;
+using TogglOutlookPlugIn.Synchronization;
 using Office = Microsoft.Office.Core;
 
 namespace TogglOutlookPlugIn
@@ -34,6 +35,9 @@ namespace TogglOutlookPlugIn
 
         public bool IsContextMenuMultipleItemsVisible(Office.IRibbonControl control)
             => (control.Context as Selection)?[1] is AppointmentItem;
+
+        public bool IsSyncNowVisible(Office.IRibbonControl control)
+            => SynchronizationService.Instance.SynchronizationOption != SyncOption.NoSync;
 
         public bool IsPushAsVisible(Office.IRibbonControl control)
             => Synchronization.SynchronizationService.Instance.SynchronizationOption == Synchronization.SyncOption.NoSync;
@@ -122,6 +126,11 @@ namespace TogglOutlookPlugIn
             }
 
             selectedAppointment.Save();
+        }
+
+        public void OnSyncNowClick(Office.IRibbonControl control)
+        {
+            SynchronizationService.Instance.SynchronizeWithToggl();
         }
 
         public void OnConfigureTogglPluginClick(Office.IRibbonControl control) => new Settings.SettingsDialog().ShowDialog();

--- a/src/CalendarContextMenu.xml
+++ b/src/CalendarContextMenu.xml
@@ -14,7 +14,12 @@
       <menuSeparator id="togglSeperator"/>
       <button id="fitToBoundaries" onAction="OnFitToBoundariesClick" label="Fit to boundaries" getImage="GetFitToBoundariesIcon" />
       <button id="quickPush" onAction="OnQuickPushClick" label="Quick push" getImage="GetTogglIcon" />
+      <button id="syncNowContextMenuCalendarItem" onAction="OnSyncNowClick" label="Sync now" getImage="GetTogglIcon" getVisible="IsSyncNowVisible"/>
       <dynamicMenu id="pushAs" label="Push as" getImage="GetTogglIcon" getContent="OnPushAsGetContent" getVisible="IsPushAsVisible" />
+    </contextMenu>
+    <contextMenu idMso="ContextMenuCalendarView">
+      <menuSeparator id="togglSeperatorCalendarView"/>
+      <button id="syncNowCalendarView" onAction="OnSyncNowClick" label="Sync now" getImage="GetTogglIcon" getVisible="IsSyncNowVisible"/>
     </contextMenu>
     <contextMenu idMso="ContextMenuMultipleItems">
       <menuSeparator id="togglSeperatorMultiple"/>

--- a/src/Synchronization/SynchronizationService.cs
+++ b/src/Synchronization/SynchronizationService.cs
@@ -77,7 +77,7 @@ namespace TogglOutlookPlugIn.Synchronization
             }
         }
 
-        private void SynchronizeWithToggl()
+        public void SynchronizeWithToggl()
         {
             DateTime startTime;
             DateTime endTime = DateTime.Now.Date.AddDays(1);


### PR DESCRIPTION
Thank you for this excellent Outlook plugin. It reduces tracking effort significantly.

## Motivation

It can be annoying to wait for synchronization to check if a recent change is reflected correctly in Toggl. This PR adds a "Sync now" context menu item to enable the user to trigger synchronization manually at any time.

## Implementation

- Context menu items on calendar view & appointments.
- Context menu items are hidden if "NoSync" setting is activated.